### PR TITLE
Autocomplete: generalise search-ajax & autocomplete.js (#125)

### DIFF
--- a/component/src/main/java/com/celements/structEditor/DefaultStructuredDataEditorService.java
+++ b/component/src/main/java/com/celements/structEditor/DefaultStructuredDataEditorService.java
@@ -391,15 +391,6 @@ public class DefaultStructuredDataEditorService implements StructuredDataEditorS
   }
 
   @Override
-  public List<String> getSelectTagAutocompleteJsPathList() {
-    List<String> roles = new ArrayList<>();
-    for (SelectAutocompleteRole role : selectAutocompleteRole) {
-      roles.add(role.getJsFilePath());
-    }
-    return roles;
-  }
-
-  @Override
   public boolean hasEditField(XWikiDocument cellDoc) {
     return getCellFieldName(cellDoc).isPresent();
   }

--- a/component/src/main/java/com/celements/structEditor/SelectAutocompleteRole.java
+++ b/component/src/main/java/com/celements/structEditor/SelectAutocompleteRole.java
@@ -2,12 +2,14 @@ package com.celements.structEditor;
 
 import java.util.Optional;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 
 import org.xwiki.component.annotation.ComponentRole;
 import org.xwiki.model.reference.DocumentReference;
 
 import com.celements.sajson.JsonBuilder;
+import com.celements.search.lucene.LuceneSearchResult;
 
 @ComponentRole
 public interface SelectAutocompleteRole {
@@ -16,15 +18,18 @@ public interface SelectAutocompleteRole {
   String getName();
 
   @NotNull
-  String getCssClass();
+  String getJsFilePath();
 
   @NotNull
-  String getJsFilePath();
+  LuceneSearchResult search(@Nullable String searchTerm);
 
   @NotNull
   Optional<DocumentReference> getSelectedValue(@NotNull DocumentReference selectCellDocRef);
 
   @NotNull
   JsonBuilder getJsonForValue(@NotNull DocumentReference valueDocRef);
+
+  @NotNull
+  String displayNameForValue(@NotNull DocumentReference valueDocRef);
 
 }

--- a/component/src/main/java/com/celements/structEditor/StructuredDataEditorScriptService.java
+++ b/component/src/main/java/com/celements/structEditor/StructuredDataEditorScriptService.java
@@ -151,10 +151,6 @@ public class StructuredDataEditorScriptService implements ScriptService {
             .orElse(false);
   }
 
-  public List<String> getSelectTagAutocompleteJsPathList() {
-    return service.getSelectTagAutocompleteJsPathList();
-  }
-
   public Optional<SelectAutocompleteRole> getSelectTagAutoCompleteImpl(
       DocumentReference cellDocRef) {
     return selectTagService.getTypeImpl(cellDocRef);

--- a/component/src/main/java/com/celements/structEditor/StructuredDataEditorService.java
+++ b/component/src/main/java/com/celements/structEditor/StructuredDataEditorService.java
@@ -65,9 +65,6 @@ public interface StructuredDataEditorService {
   List<String> getCellListValue(@NotNull DocumentReference cellDocRef,
       @Nullable XWikiDocument onDoc) throws DocumentNotExistsException;
 
-  @NotNull
-  List<String> getSelectTagAutocompleteJsPathList();
-
   boolean hasEditField(@NotNull XWikiDocument cellDoc);
 
   boolean isMultilingual(@NotNull XWikiDocument cellDoc);

--- a/component/src/main/java/com/celements/structEditor/classes/DateTimePickerEditorClass.java
+++ b/component/src/main/java/com/celements/structEditor/classes/DateTimePickerEditorClass.java
@@ -27,33 +27,21 @@ public class DateTimePickerEditorClass extends AbstractClassDefinition implement
   }
 
   public static final ClassField<List<Type>> FIELD_TYPE = new EnumListField.Builder<>(
-      CLASS_DEF_HINT, "datetimepicker_type", Type.class).prettyName("type").multiSelect(
-          false).build();
+      CLASS_REF, "datetimepicker_type", Type.class).prettyName("type").multiSelect(false).build();
 
-  public static final ClassField<String> FIELD_FORMAT = new StringField.Builder(CLASS_DEF_HINT,
-      "datetimepicker_format").prettyName("format").build();
+  public static final ClassField<String> FIELD_FORMAT = new StringField.Builder(
+      CLASS_REF, "datetimepicker_format").prettyName("format").build();
 
-  public static final ClassField<String> FIELD_ATTRIBUTES = new StringField.Builder(CLASS_DEF_HINT,
-      "datetimepicker_attributes").prettyName("Picker Attributes").build();
+  public static final ClassField<String> FIELD_ATTRIBUTES = new StringField.Builder(
+      CLASS_REF, "datetimepicker_attributes").prettyName("Picker Attributes").build();
 
-  @Override
-  public String getName() {
-    return CLASS_DEF_HINT;
+  public DateTimePickerEditorClass() {
+    super(CLASS_REF);
   }
 
   @Override
   public boolean isInternalMapping() {
     return true;
-  }
-
-  @Override
-  protected String getClassSpaceName() {
-    return SPACE_NAME;
-  }
-
-  @Override
-  protected String getClassDocName() {
-    return DOC_NAME;
   }
 
 }

--- a/component/src/main/java/com/celements/structEditor/classes/FormFieldEditorClass.java
+++ b/component/src/main/java/com/celements/structEditor/classes/FormFieldEditorClass.java
@@ -26,37 +26,25 @@ public class FormFieldEditorClass extends AbstractClassDefinition implements Str
     POST, GET;
   }
 
-  public static final ClassField<String> FIELD_ACTION = new StringField.Builder(CLASS_DEF_HINT,
-      "form_field_action").prettyName("Action").build();
+  public static final ClassField<String> FIELD_ACTION = new StringField.Builder(
+      CLASS_REF, "form_field_action").prettyName("Action").build();
 
   public static final ClassField<List<Method>> FIELD_METHOD = new EnumListField.Builder<>(
-      CLASS_DEF_HINT, "form_field_method", Method.class).prettyName("Method").multiSelect(
-          false).build();
+      CLASS_REF, "form_field_method", Method.class).prettyName("Method").multiSelect(false).build();
 
   public static final ClassField<Boolean> FIELD_SEND_DATA_ENCODED = new BooleanField.Builder(
-      CLASS_DEF_HINT, "form_field_send_data_encoded").prettyName("Send Data Encoded").build();
+      CLASS_REF, "form_field_send_data_encoded").prettyName("Send Data Encoded").build();
 
-  public static final ClassField<String> FIELD_PREFIX = new StringField.Builder(CLASS_DEF_HINT,
-      "form_field_prefix").prettyName("Prefix").build();
+  public static final ClassField<String> FIELD_PREFIX = new StringField.Builder(
+      CLASS_REF, "form_field_prefix").prettyName("Prefix").build();
 
-  @Override
-  public String getName() {
-    return CLASS_DEF_HINT;
+  public FormFieldEditorClass() {
+    super(CLASS_REF);
   }
 
   @Override
   public boolean isInternalMapping() {
     return true;
-  }
-
-  @Override
-  protected String getClassSpaceName() {
-    return SPACE_NAME;
-  }
-
-  @Override
-  protected String getClassDocName() {
-    return DOC_NAME;
   }
 
 }

--- a/component/src/main/java/com/celements/structEditor/classes/HiddenTagEditorClass.java
+++ b/component/src/main/java/com/celements/structEditor/classes/HiddenTagEditorClass.java
@@ -18,30 +18,19 @@ public class HiddenTagEditorClass extends AbstractClassDefinition implements Str
   public static final String CLASS_DEF_HINT = SPACE_NAME + "." + DOC_NAME;
   public static final ClassReference CLASS_REF = new ClassReference(SPACE_NAME, DOC_NAME);
 
-  public static final ClassField<String> FIELD_NAME = new StringField.Builder(CLASS_DEF_HINT,
-      "hidden_tag_name").prettyName("name").build();
+  public static final ClassField<String> FIELD_NAME = new StringField.Builder(
+      CLASS_REF, "hidden_tag_name").prettyName("name").build();
 
-  public static final ClassField<String> FIELD_VALUE = new StringField.Builder(CLASS_DEF_HINT,
-      "hidden_tag_value").prettyName("value").build();
+  public static final ClassField<String> FIELD_VALUE = new StringField.Builder(
+      CLASS_REF, "hidden_tag_value").prettyName("value").build();
 
-  @Override
-  public String getName() {
-    return CLASS_DEF_HINT;
+  public HiddenTagEditorClass() {
+    super(CLASS_REF);
   }
 
   @Override
   public boolean isInternalMapping() {
     return true;
-  }
-
-  @Override
-  protected String getClassSpaceName() {
-    return SPACE_NAME;
-  }
-
-  @Override
-  protected String getClassDocName() {
-    return DOC_NAME;
   }
 
 }

--- a/component/src/main/java/com/celements/structEditor/classes/OptionTagEditorClass.java
+++ b/component/src/main/java/com/celements/structEditor/classes/OptionTagEditorClass.java
@@ -19,36 +19,25 @@ public class OptionTagEditorClass extends AbstractClassDefinition implements Str
   public static final String CLASS_DEF_HINT = SPACE_NAME + "." + DOC_NAME;
   public static final ClassReference CLASS_REF = new ClassReference(SPACE_NAME, DOC_NAME);
 
-  public static final ClassField<String> FIELD_VALUE = new StringField.Builder(CLASS_DEF_HINT,
-      "option_tag_value").prettyName("value").build();
+  public static final ClassField<String> FIELD_VALUE = new StringField.Builder(
+      CLASS_REF, "option_tag_value").prettyName("value").build();
 
-  public static final ClassField<String> FIELD_LABEL = new StringField.Builder(CLASS_DEF_HINT,
-      "option_tag_label").prettyName("label").build();
+  public static final ClassField<String> FIELD_LABEL = new StringField.Builder(
+      CLASS_REF, "option_tag_label").prettyName("label").build();
 
-  public static final ClassField<Boolean> FIELD_SELECTED = new BooleanField.Builder(CLASS_DEF_HINT,
-      "option_tag_is_selected").prettyName("Is Selected").build();
+  public static final ClassField<Boolean> FIELD_SELECTED = new BooleanField.Builder(
+      CLASS_REF, "option_tag_is_selected").prettyName("Is Selected").build();
 
-  public static final ClassField<Boolean> FIELD_DISABLED = new BooleanField.Builder(CLASS_DEF_HINT,
-      "option_tag_is_disabled").prettyName("Is Disabled").build();
+  public static final ClassField<Boolean> FIELD_DISABLED = new BooleanField.Builder(
+      CLASS_REF, "option_tag_is_disabled").prettyName("Is Disabled").build();
 
-  @Override
-  public String getName() {
-    return CLASS_DEF_HINT;
+  public OptionTagEditorClass() {
+    super(CLASS_REF);
   }
 
   @Override
   public boolean isInternalMapping() {
     return true;
-  }
-
-  @Override
-  protected String getClassSpaceName() {
-    return SPACE_NAME;
-  }
-
-  @Override
-  protected String getClassDocName() {
-    return DOC_NAME;
   }
 
 }

--- a/component/src/main/java/com/celements/structEditor/classes/SelectTagAutocompleteEditorClass.java
+++ b/component/src/main/java/com/celements/structEditor/classes/SelectTagAutocompleteEditorClass.java
@@ -16,8 +16,8 @@ import com.celements.structEditor.SelectAutocompleteRole;
 
 @Singleton
 @Component(SelectTagAutocompleteEditorClass.CLASS_DEF_HINT)
-public class SelectTagAutocompleteEditorClass extends AbstractClassDefinition implements
-    StructEditorClass {
+public class SelectTagAutocompleteEditorClass extends AbstractClassDefinition
+    implements StructEditorClass {
 
   public static final String SPACE_NAME = "Celements";
   public static final String DOC_NAME = "SelectTagAutocompleteEditorClass";
@@ -26,33 +26,22 @@ public class SelectTagAutocompleteEditorClass extends AbstractClassDefinition im
   public static final ClassReference CLASS_REF = new ClassReference(SPACE_NAME, DOC_NAME);
 
   public static final ClassField<String> FIELD_AUTOCOMPLETE_SEPARATOR = new StringField.Builder(
-      CLASS_FN, "select_tag_autocomplete_separator").prettyName("Separator").build();
+      CLASS_REF, "select_tag_autocomplete_separator").prettyName("Separator").build();
 
-  public static ClassField<List<SelectAutocompleteRole>> FIELD_AUTOCOMPLETE_TYPE = new ComponentListField.Builder<>(
-      CLASS_FN, "select_tag_autocomplete_type", SelectAutocompleteRole.class).multiSelect(
-          false).separator("|").prettyName("Autocomplete Type").build();
+  public static final ClassField<List<SelectAutocompleteRole>> FIELD_AUTOCOMPLETE_TYPE = new ComponentListField.Builder<>(
+      CLASS_REF, "select_tag_autocomplete_type", SelectAutocompleteRole.class)
+          .multiSelect(false).separator("|").prettyName("Autocomplete Type").build();
 
   public static final ClassField<Boolean> FIELD_AUTOCOMPLETE_IS_MULTISELECT = new BooleanField.Builder(
-      CLASS_FN, "select_tag_autocomplete_is_multiselect").prettyName("Is Multiselect").build();
+      CLASS_REF, "select_tag_autocomplete_is_multiselect").prettyName("Is Multiselect").build();
 
-  @Override
-  public String getName() {
-    return CLASS_DEF_HINT;
+  public SelectTagAutocompleteEditorClass() {
+    super(CLASS_REF);
   }
 
   @Override
   public boolean isInternalMapping() {
     return true;
-  }
-
-  @Override
-  protected String getClassSpaceName() {
-    return SPACE_NAME;
-  }
-
-  @Override
-  protected String getClassDocName() {
-    return DOC_NAME;
   }
 
 }

--- a/component/src/main/java/com/celements/structEditor/classes/SelectTagEditorClass.java
+++ b/component/src/main/java/com/celements/structEditor/classes/SelectTagEditorClass.java
@@ -20,36 +20,25 @@ public class SelectTagEditorClass extends AbstractClassDefinition implements Str
   public static final String CLASS_DEF_HINT = SPACE_NAME + "." + DOC_NAME;
   public static final ClassReference CLASS_REF = new ClassReference(SPACE_NAME, DOC_NAME);
 
-  public static final ClassField<String> FIELD_SEPARATOR = new StringField.Builder(CLASS_DEF_HINT,
-      "select_tag_separator").prettyName("Separator").build();
+  public static final ClassField<String> FIELD_SEPARATOR = new StringField.Builder(
+      CLASS_REF, "select_tag_separator").prettyName("Separator").build();
 
   public static final ClassField<Boolean> FIELD_IS_BOOTSTRAP = new BooleanField.Builder(
-      CLASS_DEF_HINT, "select_tag_is_bootstrap").prettyName("Is Bootstrap").build();
+      CLASS_REF, "select_tag_is_bootstrap").prettyName("Is Bootstrap").build();
 
   public static final ClassField<Boolean> FIELD_IS_MULTISELECT = new BooleanField.Builder(
-      CLASS_DEF_HINT, "select_tag_is_multiselect").prettyName("Is Multiselect").build();
+      CLASS_REF, "select_tag_is_multiselect").prettyName("Is Multiselect").build();
 
   public static final ClassField<String> FIELD_BOOTSTRAP_CONFIG = new LargeStringField.Builder(
-      CLASS_DEF_HINT, "select_tag_bootstrap_config").prettyName("Bootstrap Config JSON").build();
+      CLASS_REF, "select_tag_bootstrap_config").prettyName("Bootstrap Config JSON").build();
 
-  @Override
-  public String getName() {
-    return CLASS_DEF_HINT;
+  public SelectTagEditorClass() {
+    super(CLASS_REF);
   }
 
   @Override
   public boolean isInternalMapping() {
     return true;
-  }
-
-  @Override
-  protected String getClassSpaceName() {
-    return SPACE_NAME;
-  }
-
-  @Override
-  protected String getClassDocName() {
-    return DOC_NAME;
   }
 
 }

--- a/component/src/main/java/com/celements/structEditor/classes/TextAreaFieldEditorClass.java
+++ b/component/src/main/java/com/celements/structEditor/classes/TextAreaFieldEditorClass.java
@@ -20,37 +20,26 @@ public class TextAreaFieldEditorClass extends AbstractClassDefinition implements
   public static final String CLASS_DEF_HINT = SPACE_NAME + "." + DOC_NAME;
   public static final ClassReference CLASS_REF = new ClassReference(SPACE_NAME, DOC_NAME);
 
-  public static final ClassField<Integer> FIELD_ROWS = new IntField.Builder(CLASS_DEF_HINT,
-      "textarea_field_rows").prettyName("Rows").build();
+  public static final ClassField<Integer> FIELD_ROWS = new IntField.Builder(
+      CLASS_REF, "textarea_field_rows").prettyName("Rows").build();
 
-  public static final ClassField<Integer> FIELD_COLS = new IntField.Builder(CLASS_DEF_HINT,
-      "textarea_field_cols").prettyName("Columns").build();
+  public static final ClassField<Integer> FIELD_COLS = new IntField.Builder(
+      CLASS_REF, "textarea_field_cols").prettyName("Columns").build();
 
-  public static final ClassField<String> FIELD_VALUE = new LargeStringField.Builder(CLASS_DEF_HINT,
-      "textarea_field_value").rows(7).prettyName("Executional Code").build();
+  public static final ClassField<String> FIELD_VALUE = new LargeStringField.Builder(
+      CLASS_REF, "textarea_field_value").rows(7).prettyName("Executional Code").build();
 
   public static final ClassField<Boolean> FIELD_IS_RICHTEXT = new BooleanField.Builder(
-      CLASS_DEF_HINT, "textarea_field_is_richtext").prettyName("Is RichText").displayType(
-          "yesno").build();
+      CLASS_REF, "textarea_field_is_richtext").prettyName("Is RichText").displayType("yesno")
+          .build();
 
-  @Override
-  public String getName() {
-    return CLASS_DEF_HINT;
+  public TextAreaFieldEditorClass() {
+    super(CLASS_REF);
   }
 
   @Override
   public boolean isInternalMapping() {
     return true;
-  }
-
-  @Override
-  protected String getClassSpaceName() {
-    return SPACE_NAME;
-  }
-
-  @Override
-  protected String getClassDocName() {
-    return DOC_NAME;
   }
 
 }

--- a/component/src/main/java/com/celements/structEditor/fields/FormFieldPageType.java
+++ b/component/src/main/java/com/celements/structEditor/fields/FormFieldPageType.java
@@ -1,18 +1,22 @@
 package com.celements.structEditor.fields;
 
 import static com.celements.structEditor.classes.FormFieldEditorClass.*;
+import static java.lang.Boolean.*;
 
-import java.util.Collections;
+import java.util.Collection;
 import java.util.Optional;
 
 import org.xwiki.component.annotation.Component;
+import org.xwiki.component.annotation.Requirement;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.velocity.XWikiVelocityException;
 
 import com.celements.cells.attribute.AttributeBuilder;
 import com.celements.model.access.exception.DocumentNotExistsException;
+import com.celements.model.classes.ClassDefinition;
+import com.celements.model.object.xwiki.XWikiObjectFetcher;
+import com.celements.structEditor.classes.FormFieldEditorClass;
 import com.celements.structEditor.classes.FormFieldEditorClass.Method;
-import com.google.common.collect.Iterables;
 import com.xpn.xwiki.doc.XWikiDocument;
 
 @Component(FormFieldPageType.PAGETYPE_NAME)
@@ -21,6 +25,9 @@ public class FormFieldPageType extends AbstractStructFieldPageType {
   public static final String PAGETYPE_NAME = "FormField";
 
   static final String VIEW_TEMPLATE_NAME = "FormFieldView";
+
+  @Requirement(FormFieldEditorClass.CLASS_DEF_HINT)
+  private ClassDefinition classDef;
 
   @Override
   public String getName() {
@@ -42,13 +49,17 @@ public class FormFieldPageType extends AbstractStructFieldPageType {
     attrBuilder.addCssClasses("celAddValidationToForm inactive");
     try {
       XWikiDocument cellDoc = modelAccess.getDocument(cellDocRef);
-      if (modelAccess.getFieldValue(cellDoc, FIELD_SEND_DATA_ENCODED).or(true)) {
+      XWikiObjectFetcher objFetcher = XWikiObjectFetcher.on(cellDoc).filter(classDef);
+      if (objFetcher.fetchField(FIELD_SEND_DATA_ENCODED).stream().anyMatch(TRUE::equals)) {
         attrBuilder.addNonEmptyAttribute("enctype", "multipart/form-data");
       }
       attrBuilder.addNonEmptyAttribute("action", getVelocityFieldValue(cellDoc, FIELD_ACTION)
           .orElse("?"));
-      attrBuilder.addNonEmptyAttribute("method", Iterables.getFirst(modelAccess.getFieldValue(
-          cellDoc, FIELD_METHOD).or(Collections.<Method>emptyList()), Method.POST).name());
+      attrBuilder.addNonEmptyAttribute("method", objFetcher.fetchField(FIELD_METHOD)
+          .stream().flatMap(Collection::stream)
+          .findFirst().orElse(Method.POST)
+          .name());
+      attrBuilder.addNonEmptyAttribute("autocomplete", "off");
     } catch (DocumentNotExistsException | XWikiVelocityException exc) {
       log.error("failed to add all attributes for '{}'", cellDocRef, exc);
     }

--- a/component/src/main/java/com/celements/structEditor/fields/SelectTagAutocompletePageType.java
+++ b/component/src/main/java/com/celements/structEditor/fields/SelectTagAutocompletePageType.java
@@ -1,6 +1,7 @@
 package com.celements.structEditor.fields;
 
 import static com.celements.structEditor.classes.SelectTagAutocompleteEditorClass.*;
+import static java.lang.Boolean.*;
 
 import java.util.Optional;
 
@@ -11,13 +12,10 @@ import org.xwiki.model.reference.DocumentReference;
 import com.celements.cells.attribute.AttributeBuilder;
 import com.celements.model.access.exception.DocumentNotExistsException;
 import com.celements.model.classes.ClassDefinition;
-import com.celements.model.field.FieldAccessor;
-import com.celements.model.field.XObjectFieldAccessor;
 import com.celements.model.object.xwiki.XWikiObjectFetcher;
 import com.celements.struct.SelectTagServiceRole;
 import com.celements.structEditor.classes.SelectTagAutocompleteEditorClass;
 import com.xpn.xwiki.doc.XWikiDocument;
-import com.xpn.xwiki.objects.BaseObject;
 
 @Component(SelectTagAutocompletePageType.PAGETYPE_NAME)
 public class SelectTagAutocompletePageType extends AbstractStructFieldPageType {
@@ -27,10 +25,7 @@ public class SelectTagAutocompletePageType extends AbstractStructFieldPageType {
   static final String VIEW_TEMPLATE_NAME = "SelectTagAutocompleteView";
 
   @Requirement(SelectTagAutocompleteEditorClass.CLASS_DEF_HINT)
-  private ClassDefinition selectTagAutocomplete;
-
-  @Requirement(XObjectFieldAccessor.NAME)
-  private FieldAccessor<BaseObject> xObjFieldAccessor;
+  private ClassDefinition classDef;
 
   @Requirement
   private SelectTagServiceRole selectTagService;
@@ -57,13 +52,16 @@ public class SelectTagAutocompletePageType extends AbstractStructFieldPageType {
       XWikiDocument currDoc = modelContext.getCurrentDoc().orNull();
       attrBuilder.addNonEmptyAttribute("name", getStructDataEditorService().getAttributeName(
           cellDoc, currDoc).orElse(""));
-      XWikiObjectFetcher xObjFetcher = XWikiObjectFetcher.on(cellDoc).filter(selectTagAutocomplete);
-      selectTagService.getTypeImpl(cellDocRef)
-          .ifPresent(type -> attrBuilder.addCssClasses(type.getCssClass()));
-      if (xObjFetcher.fetchField(FIELD_AUTOCOMPLETE_IS_MULTISELECT).first().or(false)) {
+      attrBuilder.addCssClasses("structAutocomplete");
+      XWikiObjectFetcher fetcher = XWikiObjectFetcher.on(cellDoc).filter(classDef);
+      selectTagService.getTypeImpl(cellDocRef).ifPresent(type -> {
+        attrBuilder.addCssClasses(type.getName());
+        attrBuilder.addNonEmptyAttribute("data-autocomplete-type", type.getName());
+      });
+      if (fetcher.fetchField(FIELD_AUTOCOMPLETE_IS_MULTISELECT).stream().anyMatch(TRUE::equals)) {
         attrBuilder.addNonEmptyAttribute("multiple", "multiple");
       }
-      xObjFetcher.fetchField(FIELD_AUTOCOMPLETE_SEPARATOR).first().toJavaUtil()
+      fetcher.fetchField(FIELD_AUTOCOMPLETE_SEPARATOR).stream().findFirst()
           .ifPresent(separator -> attrBuilder.addNonEmptyAttribute("data-separator", separator));
       getStructDataEditorService().getCellValueAsString(cellDocRef, currDoc)
           .ifPresent(docFN -> attrBuilder.addNonEmptyAttribute("data-value", docFN));

--- a/component/src/test/java/com/celements/structEditor/fields/SelectTagAutocompletePageTypeTest.java
+++ b/component/src/test/java/com/celements/structEditor/fields/SelectTagAutocompletePageTypeTest.java
@@ -17,6 +17,7 @@ import com.celements.common.test.AbstractComponentTest;
 import com.celements.model.access.ModelAccessStrategy;
 import com.celements.pagetype.java.IJavaPageTypeRole;
 import com.celements.struct.SelectTagServiceRole;
+import com.celements.structEditor.SelectAutocompleteRole;
 import com.celements.structEditor.StructuredDataEditorService;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.BaseObject;
@@ -27,12 +28,14 @@ public class SelectTagAutocompletePageTypeTest extends AbstractComponentTest {
   private SelectTagAutocompletePageType pageType;
   private SelectTagServiceRole selectTagSrvMock;
   private StructuredDataEditorService structDataEditorSrvMock;
+  private SelectAutocompleteRole autocompleteMock;
 
   @Before
   public void setUp_OptionTagPageTypeTest() throws Exception {
     registerComponentMock(ModelAccessStrategy.class);
     selectTagSrvMock = registerComponentMock(SelectTagServiceRole.class);
     structDataEditorSrvMock = registerComponentMock(StructuredDataEditorService.class);
+    autocompleteMock = createMockAndAddToDefault(SelectAutocompleteRole.class);
     pageType = (SelectTagAutocompletePageType) Utils.getComponent(IJavaPageTypeRole.class,
         SelectTagAutocompletePageType.PAGETYPE_NAME);
   }
@@ -81,17 +84,21 @@ public class SelectTagAutocompletePageTypeTest extends AbstractComponentTest {
     expect(structDataEditorSrvMock.getCellValueAsString(cellDoc.getDocumentReference(), currentDoc))
         .andReturn(Optional.of("Space.Class"));
     expect(selectTagSrvMock.getTypeImpl(cellDoc.getDocumentReference()))
-        .andReturn(java.util.Optional.empty());
+        .andReturn(Optional.of(autocompleteMock));
+    expect(autocompleteMock.getName()).andReturn("impl").anyTimes();
 
     replayDefault();
     pageType.collectAttributes(attributes, cellDoc.getDocumentReference());
     verifyDefault();
 
-    assertEquals(4, attributes.build().size());
+    assertEquals(6, attributes.build().size());
+    assertAttribute(attributes, "class", "structAutocomplete impl");
     assertAttribute(attributes, "name", "anyName");
     assertAttribute(attributes, "multiple", "multiple");
+    assertAttribute(attributes, "data-autocomplete-type", "impl");
     assertAttribute(attributes, "data-separator", "|");
     assertAttribute(attributes, "data-value", "Space.Class");
+
   }
 
   private static final XWikiDocument expectDoc(DocumentReference docRef) {

--- a/web-module/pom.xml
+++ b/web-module/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.celements</groupId>
       <artifactId>celements-structuredDataEditor</artifactId>
-      <version>4.9</version>
+      <version>4.10-SNAPSHOT</version>
     </dependency>
   </dependencies>
   <build>

--- a/web-module/src/main/webapp/resources/structEditJS/autocomplete.js
+++ b/web-module/src/main/webapp/resources/structEditJS/autocomplete.js
@@ -1,0 +1,142 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+(function(window, undefined) {
+  "use strict";
+
+  //TODO [CELDEV-937] Struct autocomplete.js refactoring to Class 
+
+  if(typeof window.CELEMENTS.structEdit=="undefined"){window.CELEMENTS.structEdit={}}
+  if(typeof window.CELEMENTS.structEdit.autocomplete=="undefined"){window.CELEMENTS.structEdit.autocomplete={};}
+  if(typeof window.CELEMENTS.structEdit.autocomplete.templates=="undefined"){window.CELEMENTS.structEdit.autocomplete.templates={};}
+
+  const checkInitAutocomplete = function() {
+    if (!celMessages.progMsg) {
+      console.debug('observe cel:messagesLoaded for initAutocomplete ');
+      $(document.body).stopObserving('cel:messagesLoaded',  initAutocomplete);
+      $(document.body).observe('cel:messagesLoaded',  initAutocomplete);
+    } else {
+      initAutocomplete();
+    }
+  };
+
+  const initAutocomplete = function() {
+    //TODO: lazily load i18n/de.js"
+    const language = ((window.celMessages && window.celMessages.celmeta)
+        ? window.celMessages.celmeta.language : '')
+        || 'de';
+    document.querySelectorAll('.structAutocomplete').forEach(selectElem => {
+      console.log('initAutocomplete:', selectElem, language)
+      const type = selectElem.dataset.autocompleteType || '';
+      const cellRef = selectElem.dataset.cellRef || '';
+      $j(selectElem).select2(buildSelect2Config(type, language, cellRef))
+      $j(selectElem).on('select2:unselect', clearSelectOptions);
+    });
+  };
+
+  /**
+   * parse the results into the format expected by Select2
+   * since we are using custom formatting functions we do not need to
+   * alter the remote JSON data, except to indicate that infinite
+   * scrolling can be used
+   */
+  const processResults = function (response, params) {
+    params.page = params.page || 1;
+    return {
+      results: response.results.map(elem => {
+          elem.id = elem.fullName;
+          elem.text = elem.name;
+          return elem;
+        }).filter(elem => elem.id && elem.text),
+      pagination: {
+        more: response.hasMore
+      }
+    };
+  };
+
+  const templateSelection = function(data) {
+    return data.text || data.id;
+  };
+
+  const getTemplateSupplier = function(type) {
+    return function(data) {
+      if (data.loading) return data.text;
+      const templateBuilder = window.CELEMENTS.structEdit.autocomplete.templates[type];
+      return templateBuilder ? templateBuilder(data) : templateSelection(data);
+    };
+  };
+
+  const clearSelectOptions = function(event) {
+    const selectElem = event.target;
+    console.debug('clearSelectOptions', selectElem);
+    selectElem.innerHTML = '<option selected="selected" value="">delete</option>';
+  };
+
+  const buildSelect2Config = function(type, language, cellRef) {
+    return {
+      language: language,
+      placeholder: celMessages.progMsg.select2["cel_select2_autocomplete_placeholder_" + type],
+      allowClear: true,
+      selectionCssClass: "structSelectContainer " + type + "SelectContainer",
+      dropdownCssClass: "structSelectDropDown " + type + "SelectDropDown",
+      ajax: buildSelect2Request(cellRef),
+      escapeMarkup: function (markup) {
+        // default Utils.escapeMarkup is HTML-escaping the value. Because
+        // we formated the value using HTML it must not be further escaped.
+        return markup;
+      },
+      minimumInputLength: 3,
+      templateResult: getTemplateSupplier(type),
+      templateSelection: templateSelection
+    };
+  };
+
+  const buildSelect2Request = function(cellRef, limit = 10) {
+    return {
+      url: "/OrgExport/REST",
+      dataType: 'json',
+      delay: 250,
+      cache: true,
+      timeout: 30000,
+      processResults : processResults,
+      data: function(params) {
+        const page = params.page || 1;
+        const offset = (page - 1 ) * limit;
+        return {
+          'ajax' : 1,
+          'xpage' : 'celements_ajax',
+          'ajax_mode' : 'struct/autocomplete/search',
+          'cellRef' : cellRef,
+          'searchterm' : params.term,
+          'page' : page,
+          'limit' : limit,
+          'offset' : offset
+        }
+      },
+      error: function(e) {
+        //TODO: PROGON-1088 - handle errors in requesting data (e.g. timeout) appropriately
+        console.log("lookup exception:", e.statusText);
+      }
+    };
+  };
+
+  celAddOnBeforeLoadListener(checkInitAutocomplete);
+
+})(window);

--- a/web-module/src/main/webapp/templates/celAjax/struct/autocomplete/search.vm
+++ b/web-module/src/main/webapp/templates/celAjax/struct/autocomplete/search.vm
@@ -1,0 +1,26 @@
+#set($jsonBuilder = $services.json.newBuilder())##
+$jsonBuilder.openDictionary()##
+#set($cellDocRef = $services.model.resolveDocument($request.cellRef))##
+#set($autoComplete = $services.structuredDataEditor.getSelectTagAutoCompleteImpl($cellDocRef).orElse($null))##
+#if($services.rightsAccess.isLoggedIn() && "$!autoComplete" != '')##
+  $jsonBuilder.addProperty('type', "$!autoComplete.name")##
+  $jsonBuilder.addProperty('searchterm', "$!request.searchterm")##
+  #set($offset = $util.parseInt("$!request.offset"))##
+  #if($offset < 0) #set($offset = 0) #end##
+  $jsonBuilder.addProperty('offset', $offset)##
+  #set($limit = $util.parseInt("$!request.limit"))##
+  #if($limit <= 0) #set($limit = 10) #end##
+  $jsonBuilder.addProperty('limit', $limit)##
+  #set($luceneSearchResult = $autoComplete.search($request.searchterm))##
+  #set($hasMore = $luceneSearchResult.getSize() > ($offset + $limit))##
+  $jsonBuilder.addProperty('hasMore', $hasMore)##
+  #set($stfu = $luceneSearchResult.setLimit($limit))##
+  #set($stfu = $luceneSearchResult.setOffset($offset))##
+  $jsonBuilder.openArray('results')##
+  #foreach ($resultDocRef in $luceneSearchResult.getResults())##
+   $jsonBuilder.addValue($autoComplete.getJsonForValue($resultDocRef))##
+  #end##
+  $jsonBuilder.closeArray()##
+#end##
+$jsonBuilder.closeDictionary()##
+$jsonBuilder.getJSON()

--- a/web-module/src/main/webapp/templates/celMacros/struct/renderEditorLayout.vm
+++ b/web-module/src/main/webapp/templates/celMacros/struct/renderEditorLayout.vm
@@ -34,13 +34,6 @@
   $services.javascript.addExtJSfileOnce(':celJS/yui/container/container-min.js', 'file')
   $services.javascript.addExtJSfileOnce(':structEditJS/StructEditor.js', 'file')
   $services.javascript.addExtJSfileOnce(':structEditJS/initStructEditor.js', 'file')
-  $services.javascript.addExtJSfileOnce(':structEditJS/select2/select2.full.min.js', 'file')
-  $services.javascript.addExtJSfileOnce(':structEditJS/select2/i18n/de.js', 'file')
-  $services.javascript.addExtJSfileOnce(':structEditJS/select2/i18n/fr.js', 'file')
-  $services.javascript.addExtJSfileOnce(':structEditJS/select2/i18n/en.js', 'file')
-  #foreach($path in $services.structuredDataEditor.getSelectTagAutocompleteJsPathList())
-    $services.javascript.addExtJSfileOnce(":${path}", 'file')
-  #end
   #set($lazyAdd = false)
   #parse("celMacros/includeCelementsRTE.vm")
 #end ## activateJsCheckUnsaved

--- a/web-module/src/main/webapp/templates/celTemplates/InputFieldView.vm
+++ b/web-module/src/main/webapp/templates/celTemplates/InputFieldView.vm
@@ -2,15 +2,13 @@
 #set($cellDocRef = $celldoc.getDocumentReference())
 #set($attrMap = $services.structuredDataEditor.getTextAttributes($cellDocRef))
 #parse('celMacros/struct/renderLabel.vm')
-<input##
-#set($requestValue = $request.getParameter("$!{attrMap.get('name')}"))
-#if("$!requestValue" != '')
- value="$requestValue"##
-#else
- value="$!services.structuredDataEditor.getCellValueAsString($cellDocRef)"##
+#set($value = $request.getParameter("$!{attrMap.get('name')}"))
+#if("$!value" == '')
+  #set($value = $services.structuredDataEditor.getCellValueAsString($cellDocRef))
 #end
+<input value="$!xwiki.getFormEncoded($value)"##
 #foreach($attrEntry in $attrMap.entrySet())
- ${attrEntry.key}="$!{attrEntry.value}"##
+ ${attrEntry.key}="$!xwiki.getFormEncoded($attrEntry.value)"##
 #end
 >
 #parse('celMacros/struct/renderLangHiddenField.vm')

--- a/web-module/src/main/webapp/templates/celTemplates/SelectTagAutocompleteView.vm
+++ b/web-module/src/main/webapp/templates/celTemplates/SelectTagAutocompleteView.vm
@@ -4,15 +4,23 @@
 #set($cellDocRef = $celldoc.getDocumentReference())
 #set($supportedClasses = ['ListClass','StaticListClass','DBListClass','DBTreeListClass','UsersClass','GroupsClass','LevelsClass'])
 #set($supportedDisplayTypes = ['select'])
-#set($autoCompleteImpl = $services.structuredDataEditor.getSelectTagAutoCompleteImpl($cellDocRef))
+#set($autoComplete = $services.structuredDataEditor.getSelectTagAutoCompleteImpl($cellDocRef).orElse($null))
 #set($propClass = $services.structuredDataEditor.getCellPropertyClass($cellDocRef))
-#if($autoCompleteImpl.isPresent())
-  #set($autoComplete = $autoCompleteImpl.get())
-  #set($currentDocRefValue = $autoComplete.getSelectedValue($cellDocRef))
-  #if($currentDocRefValue.isPresent())
-    #set($jsonBuilder = $!autoComplete.getJsonForValue($!currentDocRefValue.get()))
-    <option selected="selected" data-cel-selected-json="$escapetool.html($jsonBuilder.getJSON())"##
- value="$services.model.serialize($!currentDocRefValue.get(), 'default')"></option>
+#if("$!autoComplete" != '')
+  $services.javascript.addExtJSfileOnce(':structEditJS/select2/select2.full.min.js', 'file')
+  $services.javascript.addExtJSfileOnce(':structEditJS/select2/i18n/de.js', 'file')
+  $services.javascript.addExtJSfileOnce(':structEditJS/select2/i18n/fr.js', 'file')
+  $services.javascript.addExtJSfileOnce(':structEditJS/select2/i18n/en.js', 'file')
+  $services.javascript.addExtJSfileOnce(":structEditJS/autocomplete.js", 'file')
+  #if("$!autoComplete.jsFilePath" != '')
+    $services.javascript.addExtJSfileOnce(":${autoComplete.jsFilePath}", 'file')
+  #end
+  #set($currentDocRefValue = $autoComplete.getSelectedValue($cellDocRef).orElse($null))
+  #if("$!currentDocRefValue" != '')
+    #set($value = $services.model.serialize($!currentDocRefValue, 'default'))
+    <option selected="selected" value="$!xwiki.getFormEncoded($value)">
+      $!autoComplete.displayNameForValue($!currentDocRefValue)
+    </option>
   #else
   <!-- currentDocRefValue is empty!! -->
   #end

--- a/web-module/src/main/webapp/templates/celTemplates/SelectTagView.vm
+++ b/web-module/src/main/webapp/templates/celTemplates/SelectTagView.vm
@@ -19,7 +19,7 @@
   #if($isMultiselect)
     #set($celValues = $services.structuredDataEditor.getCellListValue($cellDocRef))
   #else
-    #set($celValues = $services.structuredDataEditor.getCellValueAsString($cellDocRef))
+    #set($celValues = [$services.structuredDataEditor.getCellValueAsString($cellDocRef)])
   #end
   #set($valueMap = $propClass.get().getMapValues())
   #foreach($keyValue in $propClass.get().getListValues())
@@ -32,10 +32,6 @@
     #if("$!displayValue" == "")
       #set($displayValue = $keyValue)
     #end
-    #if($isMultiselect)
-      <option value="$!keyValue" #if($celValues.contains($keyValue)) selected #end>$!displayValue</option>
-    #else
-      <option value="$!keyValue" #if("$celValues" == "$keyValue") selected #end>$!displayValue</option>
-    #end
+    <option value="$!xwiki.getFormEncoded($keyValue)" #if($celValues.contains($keyValue)) selected #end>$!displayValue</option>
   #end
 #end


### PR DESCRIPTION
* SelectAutocompleteLuceneRole

* autocomplete search

* encode form values

* update dependency

* add form autocomplete off

* add @ComponentRole

* simplify DefaultSelectTagService

* improve search result

* generalise SelectTagAutocomplete attributes

* improve SelectTagAutocompletePageTypeTest

* remove getSelectTagAutocompleteJsPathList

* include js in SelectTagAutocompleteView

* extend all SelectAutocompleteRole with #search

* autocomplete.js

* displayNameForValue

* move select2 js includes

* processResults add filter

* refactor class definitions

* add license and todo issue

* simplify SelectTagView