### PR TITLE
CELDEV-1124 - correct naming of extJsParamDefer

### DIFF
--- a/web-module/src/main/webapp/templates/celTemplates/DateTimeView.vm
+++ b/web-module/src/main/webapp/templates/celTemplates/DateTimeView.vm
@@ -8,6 +8,6 @@
 #end
 <!-- DateTimeView -->
 <span class='cel_lazyloadJS' style='display: none;'>celJS/jquery-format/jquery.format-1.3.min.js</span>
-$!jsService.includeExtJsFile($extJsParamDefer.setJsFile(':celJS/jquery-format/jquery.format-1.3.min.js'))
+$!jsService.includeExtJsFile($extJsParam.setJsFile(':celJS/jquery-format/jquery.format-1.3.min.js'))
 <span class='cel_lazyloadJS' style='display: none;'>structEditJS/dateTime/celements-date-time-field.js</span>
-$!jsService.includeExtJsFile($extJsParamDefer.setJsFile(':structEditJS/dateTime/celements-date-time-field.js'))
+$!jsService.includeExtJsFile($extJsParam.setJsFile(':structEditJS/dateTime/celements-date-time-field.js'))


### PR DESCRIPTION
caused by
https://synjira.atlassian.net/browse/CELDEV-1124