### PR TITLE
Move XML templates and context menus to correct web-module subprojects

### DIFF
--- a/web-module/src/main/webapp/docs/celements2web/CelementsContextMenu/cel_cm_structured_data_editor.xml
+++ b/web-module/src/main/webapp/docs/celements2web/CelementsContextMenu/cel_cm_structured_data_editor.xml
@@ -3,7 +3,7 @@
 <web>CelementsContextMenu</web>
 <name>cel_cm_structured_data_editor</name>
 <language></language>
-<defaultLanguage>en</defaultLanguage>
+<defaultLanguage>de</defaultLanguage>
 <translation>0</translation>
 <parent></parent>
 <creator>xwiki:XWiki.fpichler</creator>

--- a/web-module/src/main/webapp/docs/celements2web/CelementsContextMenu/cel_cm_structured_data_editor.xml
+++ b/web-module/src/main/webapp/docs/celements2web/CelementsContextMenu/cel_cm_structured_data_editor.xml
@@ -3,7 +3,7 @@
 <web>CelementsContextMenu</web>
 <name>cel_cm_structured_data_editor</name>
 <language></language>
-<defaultLanguage>de</defaultLanguage>
+<defaultLanguage></defaultLanguage>
 <translation>0</translation>
 <parent></parent>
 <creator>xwiki:XWiki.fpichler</creator>


### PR DESCRIPTION
This change refactors the location of various XML templates, page types, and context menus. Files that were previously added or modified in the main `celements-web` repository but logically belong to other component repositories have been relocated to their correct web-module subprojects. 

Across all touched repositories, these changes have been committed and pushed under the branch:
`update-celements2web-7x-onDisk`
